### PR TITLE
Update to "Address ES6 failling tests" by paOol 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ report
 
 .build/
 .nyc_output/
+
+dev\.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -1393,7 +1393,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -4,10 +4,7 @@
   "description": "A simple, safe, and powerful JavaScript Bitcoin Cash library.",
   "author": "Clemens Ley <ley.clemens@gmail.com>",
   "main": "src/bitcoincash.js",
-  "files": [
-    "src/",
-    "dist/"
-  ],
+  "files": ["src/", "dist/"],
   "scripts": {
     "build": "node scripts/build.js",
     "build:tests": "node scripts/build-tests.js",
@@ -83,7 +80,9 @@
   },
   "prettier": {
     "singleQuote": true,
-    "printWidth": 100
+    "printWidth": 120,
+    "trailingComma": "all",
+    "proseWrap" : "preserve"
   },
   "license": "MIT"
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,10 @@
   "description": "A simple, safe, and powerful JavaScript Bitcoin Cash library.",
   "author": "Clemens Ley <ley.clemens@gmail.com>",
   "main": "src/bitcoincash.js",
-  "files": ["src/", "dist/"],
+  "files": [
+    "src/",
+    "dist/"
+  ],
   "scripts": {
     "build": "node scripts/build.js",
     "build:tests": "node scripts/build-tests.js",
@@ -82,7 +85,7 @@
     "singleQuote": true,
     "printWidth": 120,
     "trailingComma": "all",
-    "proseWrap" : "preserve"
+    "proseWrap": "preserve"
   },
   "license": "MIT"
 }

--- a/src/address.js
+++ b/src/address.js
@@ -46,599 +46,600 @@ const BITPAY_P2SH_VERSION_BYTE = 40;
  * @returns {Address} A new valid and frozen instance of an Address
  * @constructor
  */
-function Address(data, network, type) {
-  if (!(this instanceof Address)) {
-    return new Address(data, network, type);
-  }
 
-  if (_.isArray(data) && _.isNumber(network)) {
-    return Address.createMultisig(data, network, type);
-  }
+class Address {
+  constructor(data, network, type) {
+    /** @static */
+    this.LegacyFormat = 'legacy';
+    /** @static */
+    this.BitpayFormat = 'bitpay';
+    /** @static */
+    this.CashAddrFormat = 'cashaddr';
+    /** @static */
+    this.DefaultFormat = this.LegacyFormat;
 
-  if (data instanceof Address) {
-    // Immutable instance
-    return data;
-  }
+    /** @static */
+    this.PayToPublicKeyHash = 'pubkeyhash';
+    /** @static */
+    this.PayToScriptHash = 'scripthash';
 
-  $.checkArgument(
-    data,
-    'First argument is required, please include address data.',
-    'guide/address.html'
-  );
-
-  if (network && !Networks.get(network)) {
-    throw new TypeError('Second argument must be "livenet" or "testnet".');
-  }
-
-  if (type && (type !== Address.PayToPublicKeyHash && type !== Address.PayToScriptHash)) {
-    throw new TypeError('Third argument must be "pubkeyhash" or "scripthash".');
-  }
-
-  const info = this._classifyArguments(data, network, type);
-
-  // set defaults if not set
-  info.network = info.network || Networks.get(network) || Networks.defaultNetwork;
-  info.type = info.type || type || Address.PayToPublicKeyHash;
-
-  JSUtil.defineImmutable(this, {
-    hashBuffer: info.hashBuffer,
-    network: info.network,
-    type: info.type
-  });
-
-  return this;
-}
-
-/**
- * Internal function used to split different kinds of arguments of the constructor
- * @param {*} data - The encoded data in various formats
- * @param {Network|String|number=} network - The network: 'livenet' or 'testnet'
- * @param {string=} type - The type of address: 'script' or 'pubkey'
- * @returns {Object} An "info" object with "type", "network", and "hashBuffer"
- */
-Address.prototype._classifyArguments = function(data, network, type) {
-  // transform and validate input data
-  if ((data instanceof Buffer || data instanceof Uint8Array) && data.length === 20) {
-    return Address._transformHash(data);
-  }
-  if ((data instanceof Buffer || data instanceof Uint8Array) && data.length === 21) {
-    return Address._transformBuffer(data, network, type);
-  }
-  if (data instanceof PublicKey) {
-    return Address._transformPublicKey(data);
-  }
-  // eslint-disable-next-line no-use-before-define
-  if (data instanceof Script) {
-    return Address._transformScript(data, network);
-  }
-  if (typeof data === 'string') {
-    return Address._transformString(data, network, type, Address.DefaultFormat);
-  }
-  if (_.isObject(data)) {
-    return Address._transformObject(data);
-  }
-  throw new TypeError('First argument is an unrecognized data format.');
-};
-
-/** @static */
-Address.LegacyFormat = 'legacy';
-/** @static */
-Address.BitpayFormat = 'bitpay';
-/** @static */
-Address.CashAddrFormat = 'cashaddr';
-/** @static */
-Address.DefaultFormat = Address.LegacyFormat;
-
-/** @static */
-Address.PayToPublicKeyHash = 'pubkeyhash';
-/** @static */
-Address.PayToScriptHash = 'scripthash';
-
-/**
- * @param {Buffer} hash - An instance of a hash Buffer
- * @returns {Object} An object with keys: hashBuffer
- * @private
- */
-Address._transformHash = function(hash) {
-  const info = {};
-  if (!(hash instanceof Buffer) && !(hash instanceof Uint8Array)) {
-    throw new TypeError('Address supplied is not a buffer.');
-  }
-  if (hash.length !== 20) {
-    throw new TypeError('Address hashbuffers must be exactly 20 bytes.');
-  }
-  info.hashBuffer = hash;
-  return info;
-};
-
-/**
- * Deserializes an address serialized through `Address#toObject()`
- * @param {Object} data
- * @param {string} data.hash - the hash that this address encodes
- * @param {string} data.type - either 'pubkeyhash' or 'scripthash'
- * @param {Network=} data.network - the name of the network associated
- * @return {Address}
- */
-Address._transformObject = function(data) {
-  $.checkArgument(data.hash || data.hashBuffer, 'Must provide a `hash` or `hashBuffer` property');
-  $.checkArgument(data.type, 'Must provide a `type` property');
-  return {
-    hashBuffer: data.hash ? Buffer.from(data.hash, 'hex') : data.hashBuffer,
-    network: Networks.get(data.network) || Networks.defaultNetwork,
-    type: data.type
-  };
-};
-
-/**
- * Internal function to discover the network and type based on the first data byte
- *
- * @param {Buffer} buffer - An instance of a hex encoded address Buffer
- * @returns {Object} An object with keys: network and type
- * @private
- */
-Address._classifyFromVersion = function(buffer) {
-  const version = {};
-
-  const pubkeyhashNetwork = Networks.get(buffer[0], 'pubkeyhash');
-  const scripthashNetwork = Networks.get(buffer[0], 'scripthash');
-
-  if (pubkeyhashNetwork) {
-    version.network = pubkeyhashNetwork;
-    version.type = Address.PayToPublicKeyHash;
-  } else if (scripthashNetwork) {
-    version.network = scripthashNetwork;
-    version.type = Address.PayToScriptHash;
-  }
-
-  return version;
-};
-
-/**
- * Internal function to transform a bitcoin address buffer
- *
- * @param {Buffer} buffer - An instance of a hex encoded address Buffer
- * @param {string=} network - The network: 'livenet' or 'testnet'
- * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
- * @returns {Object} An object with keys: hashBuffer, network and type
- * @private
- */
-Address._transformBuffer = function(buffer, network, type) {
-  const info = {};
-  if (!(buffer instanceof Buffer) && !(buffer instanceof Uint8Array)) {
-    throw new TypeError('Address supplied is not a buffer.');
-  }
-  if (buffer.length !== 1 + 20) {
-    throw new TypeError('Address buffers must be exactly 21 bytes.');
-  }
-
-  network = Networks.get(network);
-  const bufferVersion = Address._classifyFromVersion(buffer);
-
-  if (!bufferVersion.network || (network && network !== bufferVersion.network)) {
-    throw new TypeError('Address has mismatched network type.');
-  }
-
-  if (!bufferVersion.type || (type && type !== bufferVersion.type)) {
-    throw new TypeError('Address has mismatched type.');
-  }
-
-  info.hashBuffer = buffer.slice(1);
-  info.network = bufferVersion.network;
-  info.type = bufferVersion.type;
-  return info;
-};
-
-/**
- * Internal function to transform a {@link PublicKey}
- *
- * @param {PublicKey} pubkey - An instance of PublicKey
- * @returns {Object} An object with keys: hashBuffer, type
- * @private
- */
-Address._transformPublicKey = function(pubkey) {
-  const info = {};
-  if (!(pubkey instanceof PublicKey)) {
-    throw new TypeError('Address must be an instance of PublicKey.');
-  }
-  info.hashBuffer = Hash.sha256ripemd160(pubkey.toBuffer());
-  info.type = Address.PayToPublicKeyHash;
-  return info;
-};
-
-/**
- * Internal function to transform a {@link Script} into a `info` object.
- *
- * @param {Script} script - An instance of Script
- * @returns {Object} An object with keys: hashBuffer, type
- * @private
- */
-Address._transformScript = function(script, network) {
-  // eslint-disable-next-line no-use-before-define
-  $.checkArgument(script instanceof Script, 'script must be a Script instance');
-  const info = script.getAddressInfo(network);
-  if (!info) {
-    throw new errors.Script.CantDeriveAddress(script);
-  }
-  return info;
-};
-
-/**
- * Creates a P2SH address from a set of public keys and a threshold.
- *
- * The addresses will be sorted lexicographically, as that is the trend in bitcoin.
- * To create an address from unsorted public keys, use the {@link Script#buildMultisigOut}
- * interface.
- *
- * @param {Array} publicKeys - a set of public keys to create an address
- * @param {number} threshold - the number of signatures needed to release the funds
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @return {Address}
- */
-Address.createMultisig = function(publicKeys, threshold, network) {
-  network = network || publicKeys[0].network || Networks.defaultNetwork;
-  // eslint-disable-next-line no-use-before-define
-  return Address.payingTo(Script.buildMultisigOut(publicKeys, threshold), network);
-};
-
-/**
- * Internal function to transform a bitcoin address string
- *
- * @param {string} data
- * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
- * @param {string} format - The format: 'legacy', 'bitpay' or 'cashaddr'
- * @returns {Object} An object with keys: hashBuffer, network and type
- * @private
- */
-Address._transformString = function(data, network, type, format) {
-  if (typeof data !== 'string') {
-    throw new TypeError('data parameter supplied is not a string.');
-  }
-  data = data.trim();
-  if (format === Address.LegacyFormat) {
-    return Address._transformStringLegacy(data, network, type);
-  }
-  if (format === Address.BitpayFormat) {
-    return Address._transformStringBitpay(data, network, type);
-  }
-  if (format === Address.CashAddrFormat) {
-    return Address._transformStringCashAddr(data, network, type);
-  }
-  throw new TypeError('Unrecognized address format.');
-};
-
-/**
- * Internal function to transform a bitcoin address string in legacy format
- *
- * @param {string} data
- * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
- * @returns {Object} An object with keys: hashBuffer, network and type
- * @private
- */
-Address._transformStringLegacy = function(data, network, type) {
-  const addressBuffer = Base58Check.decode(data);
-  return Address._transformBuffer(addressBuffer, network, type);
-};
-
-/**
- * Internal function to transform a bitcoin address string in Bitpay format
- *
- * @param {string} data
- * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
- * @returns {Object} An object with keys: hashBuffer, network and type
- * @private
- */
-Address._transformStringBitpay = function(data, network, type) {
-  const addressBuffer = Base58Check.decode(data);
-  if (addressBuffer[0] === BITPAY_P2PKH_VERSION_BYTE) {
-    addressBuffer[0] = 0;
-  } else if (addressBuffer[0] === BITPAY_P2SH_VERSION_BYTE) {
-    addressBuffer[0] = 5;
-  }
-  return Address._transformBuffer(addressBuffer, network, type);
-};
-
-/**
- * Internal function to transform a bitcoin address string in CashAddr format
- *
- * @param {string} data
- * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
- * @returns {Object} An object with keys: hashBuffer, network and type
- * @private
- */
-Address._transformStringCashAddr = function(data, network, type) {
-  if (!(typeof network === 'string')) {
-    network = network.toString();
-  }
-  const decoded = cashaddr.decode(data);
-  $.checkArgument(
-    !network ||
-      (network === 'livenet' && decoded.prefix === 'bitcoincash') ||
-      (network === 'testnet' && decoded.prefix === 'bchtest'),
-    'Invalid network.'
-  );
-  $.checkArgument(
-    !type ||
-      (type === Address.PayToPublicKeyHash && decoded.type === 'P2PKH') ||
-      (type === Address.PayToScriptHash && decoded.type === 'P2SH'),
-    'Invalid type.'
-  );
-  network = Networks.get(network || (decoded.prefix === 'bitcoincash' ? 'livenet' : 'testnet'));
-  type = type || (decoded.type === 'P2PKH' ? Address.PayToPublicKeyHash : Address.PayToScriptHash);
-  const version = Buffer.from([network[type]]);
-  const hashBuffer = Buffer.from(decoded.hash);
-  const addressBuffer = Buffer.concat([version, hashBuffer]);
-  return Address._transformBuffer(addressBuffer, network, type);
-};
-
-/**
- * Instantiate an address from a PublicKey instance
- *
- * @param {PublicKey} data
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.fromPublicKey = function(data, network) {
-  const info = Address._transformPublicKey(data);
-  network = network || Networks.defaultNetwork;
-  return new Address(info.hashBuffer, network, info.type);
-};
-
-/**
- * Instantiate an address from a ripemd160 public key hash
- *
- * @param {Buffer} hash - An instance of buffer of the hash
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.fromPublicKeyHash = function(hash, network) {
-  const info = Address._transformHash(hash);
-  return new Address(info.hashBuffer, network, Address.PayToPublicKeyHash);
-};
-
-/**
- * Instantiate an address from a ripemd160 script hash
- *
- * @param {Buffer} hash - An instance of buffer of the hash
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.fromScriptHash = function(hash, network) {
-  $.checkArgument(hash, 'hash parameter is required');
-  const info = Address._transformHash(hash);
-  return new Address(info.hashBuffer, network, Address.PayToScriptHash);
-};
-
-/**
- * Builds a p2sh address paying to script. This will hash the script and
- * use that to create the address.
- * If you want to extract an address associated with a script instead,
- * see {{Address#fromScript}}
- *
- * @param {Script} script - An instance of Script
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.payingTo = function(script, network) {
-  $.checkArgument(script, 'script is required');
-  // eslint-disable-next-line no-use-before-define
-  $.checkArgument(script instanceof Script, 'script must be instance of Script');
-
-  return Address.fromScriptHash(Hash.sha256ripemd160(script.toBuffer()), network);
-};
-
-/**
- * Extract address from a Script. The script must be of one
- * of the following types: p2pkh input, p2pkh output, p2sh input
- * or p2sh output.
- * This will analyze the script and extract address information from it.
- * If you want to transform any script to a p2sh Address paying
- * to that script's hash instead, use {{Address#payingTo}}
- *
- * @param {Script} script - An instance of Script
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.fromScript = function(script, network) {
-  // eslint-disable-next-line no-use-before-define
-  $.checkArgument(script instanceof Script, 'script must be a Script instance');
-  const info = Address._transformScript(script, network);
-  return new Address(info.hashBuffer, network, info.type);
-};
-
-/**
- * Instantiate an address from a buffer of the address
- *
- * @param {Buffer} buffer - An instance of buffer of the address
- * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string=} type - The type of address: 'script' or 'pubkey'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.fromBuffer = function(buffer, network, type) {
-  const info = Address._transformBuffer(buffer, network, type);
-  return new Address(info.hashBuffer, info.network, info.type);
-};
-
-/**
- * Instantiate an address from an address string
- *
- * @param {string} str - An string of the bitcoin address
- * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string=} type - The type of address: 'script' or 'pubkey'
- * @param {string=} format - The format: 'legacy', 'bitpay' or 'cashaddr'
- * @returns {Address} A new valid and frozen instance of an Address
- */
-Address.fromString = function(str, network, type, format) {
-  format = format || Address.DefaultFormat;
-  const info = Address._transformString(str, network, type, format);
-  return new Address(info.hashBuffer, info.network, info.type);
-};
-
-/**
- * Instantiate an address from an Object
- *
- * @param {string} json - An JSON string or Object with keys: hash, network and type
- * @returns {Address} A new valid instance of an Address
- */
-Address.fromObject = function fromObject(obj) {
-  $.checkState(
-    JSUtil.isHexa(obj.hash),
-    `Unexpected hash property, "${obj.hash}", expected to be hex.`
-  );
-  const hashBuffer = Buffer.from(obj.hash, 'hex');
-  return new Address(hashBuffer, obj.network, obj.type);
-};
-
-/**
- * Will return a validation error if exists
- *
- * @example
- * ```javascript
- * // a network mismatch error
- * var error = Address.getValidationError('15vkcKf7gB23wLAnZLmbVuMiiVDc1Nm4a2', 'testnet');
- * ```
- *
- * @param {string} data - The encoded data
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string} type - The type of address: 'script' or 'pubkey'
- * @returns {null|Error} The corresponding error message
- */
-Address.getValidationError = function(data, network, type) {
-  let error;
-  try {
-    // eslint-disable-next-line no-new
-    new Address(data, network, type);
-  } catch (e) {
-    error = e;
-  }
-  return error;
-};
-
-/**
- * Will return a boolean if an address is valid
- *
- * @example
- * ```javascript
- * assert(Address.isValid('15vkcKf7gB23wLAnZLmbVuMiiVDc1Nm4a2', 'livenet'));
- * ```
- *
- * @param {string} data - The encoded data
- * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
- * @param {string} type - The type of address: 'script' or 'pubkey'
- * @returns {boolean} The corresponding error message
- */
-Address.isValid = function(data, network, type) {
-  return !Address.getValidationError(data, network, type);
-};
-
-/**
- * Returns true if an address is of pay to public key hash type
- * @return boolean
- */
-Address.prototype.isPayToPublicKeyHash = function() {
-  return this.type === Address.PayToPublicKeyHash;
-};
-
-/**
- * Returns true if an address is of pay to script hash type
- * @return boolean
- */
-Address.prototype.isPayToScriptHash = function() {
-  return this.type === Address.PayToScriptHash;
-};
-
-/**
- * Will return a buffer representation of the address
- *
- * @returns {Buffer} Bitcoin address buffer
- */
-Address.prototype.toBuffer = function() {
-  const version = Buffer.from([this.network[this.type]]);
-  const buf = Buffer.concat([version, this.hashBuffer]);
-  return buf;
-};
-
-/**
- * @returns {Object} A plain object with the address information
- */
-Address.prototype.toObject = function toObject() {
-  return {
-    hash: this.hashBuffer.toString('hex'),
-    type: this.type,
-    network: this.network.toString()
-  };
-};
-
-Address.prototype.toJSON = Address.prototype.toObject;
-
-/**
- * Will return a the string representation of the address
- *
- * @param {string=} format - The format: 'legacy', 'bitpay' or 'cashaddr'
- * @returns {string} Bitcoin address
- */
-Address.prototype.toString = function(format) {
-  format = format || Address.DefaultFormat;
-  if (format === Address.LegacyFormat) {
-    return this._toStringLegacy();
-  }
-  if (format === Address.BitpayFormat) {
-    return this._toStringBitpay();
-  }
-  if (format === Address.CashAddrFormat) {
-    return this._toStringCashAddr();
-  }
-  throw new TypeError('Unrecognized address format.');
-};
-
-/**
- * Will return a the string representation of the address in legacy format
- *
- * @returns {string} Bitcoin address
- */
-Address.prototype._toStringLegacy = function() {
-  return Base58Check.encode(this.toBuffer());
-};
-
-/**
- * Will return a the string representation of the address in Bitpay format
- *
- * @returns {string} Bitcoin address
- */
-Address.prototype._toStringBitpay = function() {
-  const buffer = this.toBuffer();
-  if (this.network.toString() === 'livenet') {
-    if (this.type === Address.PayToPublicKeyHash) {
-      buffer[0] = BITPAY_P2PKH_VERSION_BYTE;
-    } else if (this.type === Address.PayToScriptHash) {
-      buffer[0] = BITPAY_P2SH_VERSION_BYTE;
+    if (!(this instanceof Address)) {
+      return new Address(data, network, type);
     }
+
+    if (_.isArray(data) && _.isNumber(network)) {
+      return this.createMultisig(data, network, type);
+    }
+
+    if (data instanceof Address) {
+      // Immutable instance
+      return data;
+    }
+
+    $.checkArgument(data, 'First argument is required, please include address data.', 'guide/address.html');
+
+    if (network && !Networks.get(network)) {
+      throw new TypeError('Second argument must be "livenet" or "testnet".');
+    }
+
+    if (type && (type !== this.PayToPublicKeyHash && type !== this.PayToScriptHash)) {
+      throw new TypeError('Third argument must be "pubkeyhash" or "scripthash".');
+    }
+
+    const info = this._classifyArguments(data, network, type);
+
+    // set defaults if not set
+    info.network = info.network || Networks.get(network) || Networks.defaultNetwork;
+    info.type = info.type || type || this.PayToPublicKeyHash;
+
+    JSUtil.defineImmutable(this, {
+      hashBuffer: info.hashBuffer,
+      network: info.network,
+      type: info.type,
+    });
+
+    return this;
   }
-  return Base58Check.encode(buffer);
-};
 
-/**
- * Will return a the string representation of the address in CashAddr format
- *
- * @returns {string} Bitcoin address
- */
-Address.prototype._toStringCashAddr = function() {
-  const prefix = this.network.toString() === 'livenet' ? 'bitcoincash' : 'bchtest';
-  const type = this.type === Address.PayToPublicKeyHash ? 'P2PKH' : 'P2SH';
-  return cashaddr.encode(prefix, type, this.hashBuffer);
-};
+  /**
+   * Internal function used to split different kinds of arguments of the constructor
+   * @param {*} data - The encoded data in various formats
+   * @param {Network|String|number=} network - The network: 'livenet' or 'testnet'
+   * @param {string=} type - The type of address: 'script' or 'pubkey'
+   * @returns {Object} An "info" object with "type", "network", and "hashBuffer"
+   */
+  _classifyArguments(data, network, type) {
+    // transform and validate input data
+    if ((data instanceof Buffer || data instanceof Uint8Array) && data.length === 20) {
+      return this._transformHash(data);
+    }
+    if ((data instanceof Buffer || data instanceof Uint8Array) && data.length === 21) {
+      return this._transformBuffer(data, network, type);
+    }
+    if (data instanceof PublicKey) {
+      return this._transformPublicKey(data);
+    }
+    // eslint-disable-next-line no-use-before-define
+    if (data instanceof Script) {
+      return this._transformScript(data, network);
+    }
+    if (typeof data === 'string') {
+      return this._transformString(data, network, type, this.DefaultFormat);
+    }
+    if (_.isObject(data)) {
+      return this._transformObject(data);
+    }
+    throw new TypeError('First argument is an unrecognized data format.');
+  }
 
-/**
- * Will return a string formatted for the console
- *
- * @returns {string} Bitcoin address
- */
-Address.prototype.inspect = function() {
-  return `<Address: ${this.toString()}, type: ${this.type}, network: ${this.network}>`;
-};
+  /**
+   * @param {Buffer} hash - An instance of a hash Buffer
+   * @returns {Object} An object with keys: hashBuffer
+   * @private
+   */
+  static _transformHash(hash) {
+    const info = {};
+    if (!(hash instanceof Buffer) && !(hash instanceof Uint8Array)) {
+      throw new TypeError('Address supplied is not a buffer.');
+    }
+    if (hash.length !== 20) {
+      throw new TypeError('Address hashbuffers must be exactly 20 bytes.');
+    }
+    info.hashBuffer = hash;
+    return info;
+  }
+
+  /**
+   * Deserializes an address serialized through `Address#toObject()`
+   * @param {Object} data
+   * @param {string} data.hash - the hash that this address encodes
+   * @param {string} data.type - either 'pubkeyhash' or 'scripthash'
+   * @param {Network=} data.network - the name of the network associated
+   * @return {Address}
+   */
+  static _transformObject(data) {
+    $.checkArgument(data.hash || data.hashBuffer, 'Must provide a `hash` or `hashBuffer` property');
+    $.checkArgument(data.type, 'Must provide a `type` property');
+    return {
+      hashBuffer: data.hash ? Buffer.from(data.hash, 'hex') : data.hashBuffer,
+      network: Networks.get(data.network) || Networks.defaultNetwork,
+      type: data.type,
+    };
+  }
+
+  /**
+   * Internal function to discover the network and type based on the first data byte
+   *
+   * @param {Buffer} buffer - An instance of a hex encoded address Buffer
+   * @returns {Object} An object with keys: network and type
+   * @private
+   */
+  static _classifyFromVersion(buffer) {
+    const version = {};
+
+    const pubkeyhashNetwork = Networks.get(buffer[0], 'pubkeyhash');
+    const scripthashNetwork = Networks.get(buffer[0], 'scripthash');
+
+    if (pubkeyhashNetwork) {
+      version.network = pubkeyhashNetwork;
+      version.type = this.PayToPublicKeyHash;
+    } else if (scripthashNetwork) {
+      version.network = scripthashNetwork;
+      version.type = this.PayToScriptHash;
+    }
+
+    return version;
+  }
+
+  /**
+   * Internal function to transform a bitcoin address buffer
+   *
+   * @param {Buffer} buffer - An instance of a hex encoded address Buffer
+   * @param {string=} network - The network: 'livenet' or 'testnet'
+   * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
+   * @returns {Object} An object with keys: hashBuffer, network and type
+   * @private
+   */
+  static _transformBuffer(buffer, network, type) {
+    const info = {};
+    if (!(buffer instanceof Buffer) && !(buffer instanceof Uint8Array)) {
+      throw new TypeError('Address supplied is not a buffer.');
+    }
+    if (buffer.length !== 1 + 20) {
+      throw new TypeError('Address buffers must be exactly 21 bytes.');
+    }
+
+    network = Networks.get(network);
+    const bufferVersion = this._classifyFromVersion(buffer);
+
+    if (!bufferVersion.network || (network && network !== bufferVersion.network)) {
+      throw new TypeError('Address has mismatched network type.');
+    }
+
+    if (!bufferVersion.type || (type && type !== bufferVersion.type)) {
+      throw new TypeError('Address has mismatched type.');
+    }
+
+    info.hashBuffer = buffer.slice(1);
+    info.network = bufferVersion.network;
+    info.type = bufferVersion.type;
+    return info;
+  }
+
+  /**
+   * Internal function to transform a {@link PublicKey}
+   *
+   * @param {PublicKey} pubkey - An instance of PublicKey
+   * @returns {Object} An object with keys: hashBuffer, type
+   * @private
+   */
+  static _transformPublicKey(pubkey) {
+    const info = {};
+    if (!(pubkey instanceof PublicKey)) {
+      throw new TypeError('Address must be an instance of PublicKey.');
+    }
+    info.hashBuffer = Hash.sha256ripemd160(pubkey.toBuffer());
+    info.type = this.PayToPublicKeyHash;
+    return info;
+  }
+
+  /**
+   * Internal function to transform a {@link Script} into a `info` object.
+   *
+   * @param {Script} script - An instance of Script
+   * @returns {Object} An object with keys: hashBuffer, type
+   * @private
+   */
+  static _transformScript(script, network) {
+    // eslint-disable-next-line no-use-before-define
+    $.checkArgument(script instanceof Script, 'script must be a Script instance');
+    const info = script.getAddressInfo(network);
+    if (!info) {
+      throw new errors.Script.CantDeriveAddress(script);
+    }
+    return info;
+  }
+
+  /**
+   * Creates a P2SH address from a set of public keys and a threshold.
+   *
+   * The addresses will be sorted lexicographically, as that is the trend in bitcoin.
+   * To create an address from unsorted public keys, use the {@link Script#buildMultisigOut}
+   * interface.
+   *
+   * @param {Array} publicKeys - a set of public keys to create an address
+   * @param {number} threshold - the number of signatures needed to release the funds
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @return {Address}
+   */
+  createMultisig(publicKeys, threshold, network) {
+    network = network || publicKeys[0].network || Networks.defaultNetwork;
+    // eslint-disable-next-line no-use-before-define
+    return this.payingTo(Script.buildMultisigOut(publicKeys, threshold), network);
+  }
+
+  /**
+   * Internal function to transform a bitcoin address string
+   *
+   * @param {string} data
+   * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
+   * @param {string} format - The format: 'legacy', 'bitpay' or 'cashaddr'
+   * @returns {Object} An object with keys: hashBuffer, network and type
+   * @private
+   */
+  _transformString(data, network, type, format) {
+    if (typeof data !== 'string') {
+      throw new TypeError('data parameter supplied is not a string.');
+    }
+    data = data.trim();
+    if (format === this.LegacyFormat) {
+      return this._transformStringLegacy(data, network, type);
+    }
+    if (format === this.BitpayFormat) {
+      return this._transformStringBitpay(data, network, type);
+    }
+    if (format === this.CashAddrFormat) {
+      return this._transformStringCashAddr(data, network, type);
+    }
+    throw new TypeError('Unrecognized address format.');
+  }
+
+  /**
+   * Internal function to transform a bitcoin address string in legacy format
+   *
+   * @param {string} data
+   * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
+   * @returns {Object} An object with keys: hashBuffer, network and type
+   * @private
+   */
+  _transformStringLegacy(data, network, type) {
+    const addressBuffer = Base58Check.decode(data);
+    return this._transformBuffer(addressBuffer, network, type);
+  }
+
+  /**
+   * Internal function to transform a bitcoin address string in Bitpay format
+   *
+   * @param {string} data
+   * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
+   * @returns {Object} An object with keys: hashBuffer, network and type
+   * @private
+   */
+  _transformStringBitpay(data, network, type) {
+    const addressBuffer = Base58Check.decode(data);
+    if (addressBuffer[0] === BITPAY_P2PKH_VERSION_BYTE) {
+      addressBuffer[0] = 0;
+    } else if (addressBuffer[0] === BITPAY_P2SH_VERSION_BYTE) {
+      addressBuffer[0] = 5;
+    }
+    return this._transformBuffer(addressBuffer, network, type);
+  }
+
+  /**
+   * Internal function to transform a bitcoin address string in CashAddr format
+   *
+   * @param {string} data
+   * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string=} type - The type: 'pubkeyhash' or 'scripthash'
+   * @returns {Object} An object with keys: hashBuffer, network and type
+   * @private
+   */
+  _transformStringCashAddr(data, network, type) {
+    if (!(typeof network === 'string')) {
+      network = network.toString();
+    }
+    const decoded = cashaddr.decode(data);
+    $.checkArgument(
+      !network ||
+        (network === 'livenet' && decoded.prefix === 'bitcoincash') ||
+        (network === 'testnet' && decoded.prefix === 'bchtest'),
+      'Invalid network.',
+    );
+    $.checkArgument(
+      !type ||
+        (type === this.PayToPublicKeyHash && decoded.type === 'P2PKH') ||
+        (type === this.PayToScriptHash && decoded.type === 'P2SH'),
+      'Invalid type.',
+    );
+    network = Networks.get(network || (decoded.prefix === 'bitcoincash' ? 'livenet' : 'testnet'));
+    type = type || (decoded.type === 'P2PKH' ? this.PayToPublicKeyHash : this.PayToScriptHash);
+    const version = Buffer.from([network[type]]);
+    const hashBuffer = Buffer.from(decoded.hash);
+    const addressBuffer = Buffer.concat([version, hashBuffer]);
+    return this._transformBuffer(addressBuffer, network, type);
+  }
+
+  /**
+   * Instantiate an address from a PublicKey instance
+   *
+   * @param {PublicKey} data
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  fromPublicKey(data, network) {
+    const info = this._transformPublicKey(data);
+    network = network || Networks.defaultNetwork;
+    return new Address(info.hashBuffer, network, info.type);
+  }
+
+  /**
+   * Instantiate an address from a ripemd160 public key hash
+   *
+   * @param {Buffer} hash - An instance of buffer of the hash
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  fromPublicKeyHash(hash, network) {
+    const info = this._transformHash(hash);
+    return new Address(info.hashBuffer, network, this.PayToPublicKeyHash);
+  }
+
+  /**
+   * Instantiate an address from a ripemd160 script hash
+   *
+   * @param {Buffer} hash - An instance of buffer of the hash
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  fromScriptHash(hash, network) {
+    $.checkArgument(hash, 'hash parameter is required');
+    const info = this._transformHash(hash);
+    return new Address(info.hashBuffer, network, this.PayToScriptHash);
+  }
+
+  /**
+   * Builds a p2sh address paying to script. This will hash the script and
+   * use that to create the address.
+   * If you want to extract an address associated with a script instead,
+   * see {{Address#fromScript}}
+   *
+   * @param {Script} script - An instance of Script
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  payingTo(script, network) {
+    $.checkArgument(script, 'script is required');
+    // eslint-disable-next-line no-use-before-define
+    $.checkArgument(script instanceof Script, 'script must be instance of Script');
+
+    return this.fromScriptHash(Hash.sha256ripemd160(script.toBuffer()), network);
+  }
+
+  /**
+   * Extract address from a Script. The script must be of one
+   * of the following types: p2pkh input, p2pkh output, p2sh input
+   * or p2sh output.
+   * This will analyze the script and extract address information from it.
+   * If you want to transform any script to a p2sh Address paying
+   * to that script's hash instead, use {{Address#payingTo}}
+   *
+   * @param {Script} script - An instance of Script
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  fromScript(script, network) {
+    // eslint-disable-next-line no-use-before-define
+    $.checkArgument(script instanceof Script, 'script must be a Script instance');
+    const info = this._transformScript(script, network);
+    return new Address(info.hashBuffer, network, info.type);
+  }
+
+  /**
+   * Instantiate an address from a buffer of the address
+   *
+   * @param {Buffer} buffer - An instance of buffer of the address
+   * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string=} type - The type of address: 'script' or 'pubkey'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  fromBuffer(buffer, network, type) {
+    const info = this._transformBuffer(buffer, network, type);
+    return new Address(info.hashBuffer, info.network, info.type);
+  }
+
+  /**
+   * Instantiate an address from an address string
+   *
+   * @param {string} str - An string of the bitcoin address
+   * @param {String|Network=} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string=} type - The type of address: 'script' or 'pubkey'
+   * @param {string=} format - The format: 'legacy', 'bitpay' or 'cashaddr'
+   * @returns {Address} A new valid and frozen instance of an Address
+   */
+  fromString(str, network, type, format) {
+    format = format || this.DefaultFormat;
+    const info = this._transformString(str, network, type, format);
+    return new Address(info.hashBuffer, info.network, info.type);
+  }
+
+  /**
+   * Instantiate an address from an Object
+   *
+   * @param {string} json - An JSON string or Object with keys: hash, network and type
+   * @returns {Address} A new valid instance of an Address
+   */
+
+  // possible error?
+  static fromObject(obj) {
+    $.checkState(JSUtil.isHexa(obj.hash), `Unexpected hash property, "${obj.hash}", expected to be hex.`);
+    const hashBuffer = Buffer.from(obj.hash, 'hex');
+    return new Address(hashBuffer, obj.network, obj.type);
+  }
+
+  /**
+   * Will return a validation error if exists
+   *
+   * @example
+   * ```javascript
+   * // a network mismatch error
+   * var error = this.getValidationError('15vkcKf7gB23wLAnZLmbVuMiiVDc1Nm4a2', 'testnet');
+   * ```
+   *
+   * @param {string} data - The encoded data
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string} type - The type of address: 'script' or 'pubkey'
+   * @returns {null|Error} The corresponding error message
+   */
+  static getValidationError(data, network, type) {
+    let error;
+    try {
+      // eslint-disable-next-line no-new
+      new Address(data, network, type);
+    } catch (e) {
+      error = e;
+    }
+    return error;
+  }
+
+  /**
+   * Will return a boolean if an address is valid
+   *
+   * @example
+   * ```javascript
+   * assert(this.isValid('15vkcKf7gB23wLAnZLmbVuMiiVDc1Nm4a2', 'livenet'));
+   * ```
+   *
+   * @param {string} data - The encoded data
+   * @param {String|Network} network - either a Network instance, 'livenet', or 'testnet'
+   * @param {string} type - The type of address: 'script' or 'pubkey'
+   * @returns {boolean} The corresponding error message
+   */
+  isValid(data, network, type) {
+    return !this.getValidationError(data, network, type);
+  }
+
+  /**
+   * Returns true if an address is of pay to public key hash type
+   * @return boolean
+   */
+  isPayToPublicKeyHash() {
+    return this.type === this.PayToPublicKeyHash;
+  }
+
+  /**
+   * Returns true if an address is of pay to script hash type
+   * @return boolean
+   */
+  isPayToScriptHash() {
+    return this.type === this.PayToScriptHash;
+  }
+
+  /**
+   * Will return a buffer representation of the address
+   *
+   * @returns {Buffer} Bitcoin address buffer
+   */
+  toBuffer() {
+    const version = Buffer.from([this.network[this.type]]);
+    const buf = Buffer.concat([version, this.hashBuffer]);
+    return buf;
+  }
+
+  /**
+   * @returns {Object} A plain object with the address information
+   */
+  // possible error?
+  toObject() {
+    return {
+      hash: this.hashBuffer.toString('hex'),
+      type: this.type,
+      network: this.network.toString(),
+    };
+  }
+
+  toJSON() {
+    return this.toObject();
+  }
+
+  /**
+   * Will return a the string representation of the address
+   *
+   * @param {string=} format - The format: 'legacy', 'bitpay' or 'cashaddr'
+   * @returns {string} Bitcoin address
+   */
+  toString(format) {
+    format = format || this.DefaultFormat;
+    if (format === this.LegacyFormat) {
+      return this.toStringLegacy();
+    }
+    if (format === this.BitpayFormat) {
+      return this.toStringBitpay();
+    }
+    if (format === this.CashAddrFormat) {
+      return this.toStringCashAddr();
+    }
+    throw new TypeError('Unrecognized address format.');
+  }
+
+  /**
+   * Will return a the string representation of the address in legacy format
+   *
+   * @returns {string} Bitcoin address
+   */
+  static _toStringLegacy() {
+    return Base58Check.encode(this.toBuffer());
+  }
+
+  /**
+   * Will return a the string representation of the address in Bitpay format
+   *
+   * @returns {string} Bitcoin address
+   */
+  static _toStringBitpay() {
+    const buffer = this.toBuffer();
+    if (this.network.toString() === 'livenet') {
+      if (this.type === this.PayToPublicKeyHash) {
+        buffer[0] = BITPAY_P2PKH_VERSION_BYTE;
+      } else if (this.type === this.PayToScriptHash) {
+        buffer[0] = BITPAY_P2SH_VERSION_BYTE;
+      }
+    }
+    return Base58Check.encode(buffer);
+  }
+
+  /**
+   * Will return a the string representation of the address in CashAddr format
+   *
+   * @returns {string} Bitcoin address
+   */
+  static _toStringCashAddr() {
+    const prefix = this.network.toString() === 'livenet' ? 'bitcoincash' : 'bchtest';
+    const type = this.type === this.PayToPublicKeyHash ? 'P2PKH' : 'P2SH';
+    return cashaddr.encode(prefix, type, this.hashBuffer);
+  }
+
+  /**
+   * Will return a string formatted for the console
+   *
+   * @returns {string} Bitcoin address
+   */
+  inspect() {
+    return `<Address: ${this.toString()}, type: ${this.type}, network: ${this.network}>`;
+  }
+}
 
 module.exports = Address;
 

--- a/src/script/script.js
+++ b/src/script/script.js
@@ -884,7 +884,7 @@ Script.prototype.toScriptHashOut = function () {
  * @return {Script} an output script built from the address
  */
 Script.fromAddress = function (address) {
-  address = Address(address);
+  address = new Address(address);
   if (address.isPayToScriptHash()) {
     return Script.buildScriptHashOut(address);
   } if (address.isPayToPublicKeyHash()) {

--- a/test/address.js
+++ b/test/address.js
@@ -318,13 +318,13 @@ describe('Address', function() {
 
     it('should error because of incorrect format for pubkey hash', function() {
       (function() {
-        return new Address.fromPublicKeyHash('notahash');
+        return Address.fromPublicKeyHash('notahash');
       }).should.throw('Address supplied is not a buffer.');
     });
 
     it('should error because of incorrect format for script hash', function() {
       (function() {
-        return new Address.fromScriptHash('notascript');
+        return Address.fromScriptHash('notascript');
       }).should.throw('Address supplied is not a buffer.');
     });
 
@@ -458,12 +458,12 @@ describe('Address', function() {
       it('returns the same address if the script is a pay to public key hash out', function() {
         var address = '16JXnhxjJUhxfyx4y6H4sFcxrgt8kQ8ewX';
         var script = Script.buildPublicKeyHashOut(new Address(address));
-        Address(script, Networks.livenet).toString().should.equal(address);
+        new Address(script, Networks.livenet).toString().should.equal(address);
       });
       it('returns the same address if the script is a pay to script hash out', function() {
         var address = '3BYmEwgV2vANrmfRymr1mFnHXgLjD6gAWm';
         var script = Script.buildScriptHashOut(new Address(address));
-        Address(script, Networks.livenet).toString().should.equal(address);
+        new Address(script, Networks.livenet).toString().should.equal(address);
       });
     });
 

--- a/test/publickey.js
+++ b/test/publickey.js
@@ -358,7 +358,6 @@ describe('PublicKey', function() {
       ['Kwr371tjA9u2rFSMZjTNun2PXXP3WPZu2afRHTcta6KxEUdm1vEw', '1NoJrossxPBKfCHuJXT4HadJrXRE9Fxiqs'],
       ['L3Hq7a8FEQwJkW1M2GNKDW28546Vp5miewcCzSqUD9kCAXrJdS3g', '1CRj2HyM1CXWzHAXLQtiGLyggNT9WQqsDs']
     ];
-    
     data.forEach(function(d){
       var publicKey = PrivateKey.fromWIF(d[0]).toPublicKey();
       var address = Address.fromString(d[1]);


### PR DESCRIPTION
I fixed the broken unit tests in paOol's pr. Actually paOol was mostly done, the problem was that some methods that were supposed to be static were not (and vice versa). I actually had to change some test cases because the old version of address allowed to use a constructor without new and this is not possible anymore. Please review my changes carefully and let me know if you agree to merge